### PR TITLE
Cannot install pycryptodomex on Termux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ termux-setup-storage
 sleep 2
 apt-get update
 apt-get -y install python ffmpeg
-pip install yt-dlp
+pip install --no-deps -U yt-dlp
 mkdir -p $YOUTUBEDL_OUTPUT_FOLDER
 mkdir -p $YOUTUBEDL_CONFIG_FOLDER
 mkdir -p $TERMUXURLOPENER_CONFIG_FOLDER


### PR DESCRIPTION
On some systems (like Termux), it is not possible to install pycryptodomex. In that case, install without dependancies

https://github.com/yt-dlp/yt-dlp