### PR TITLE
remove --restrict-filenames

### DIFF
--- a/.ytdl.conf
+++ b/.ytdl.conf
@@ -1,5 +1,4 @@
 --no-mtime
 --embed-metadata
---restrict-filenames
 -P "/data/data/com.termux/files/home/storage/shared/Youtube-DL/"
 -o "%(title).30s.%(ext)s"


### PR DESCRIPTION
HI!

--restrict-filenames option breaks videos with cyrillic titles - it names such videos like "_.mp4" and does not allow multiple videos to be downloaded without renaming.

I'm not sure if it is needed for some specific use-case, please feel free to close this PR if I am missing something.